### PR TITLE
Saab ka veidi lühemalt

### DIFF
--- a/src/juhan/tere.asm
+++ b/src/juhan/tere.asm
@@ -3,8 +3,7 @@
 ; 2. LOAD TERE
 	org	100h
 	lxi	b,Tere
-	call	0ffcdh  ; TTCon
-	jmp	0h      ; EKDOS
+	jmp	0ffcdh  ; TTCon
 Tere:	db	'Tere, Juhan!',0dh,0ah,0
 	end
 


### PR DESCRIPTION
CP/M paneb CCP return aadressi stacki enne kui programmi käivitab. Nii et programmist väljumiseks piisab ret käsust, ka TTCon lõpus olevast. -3 baiti.